### PR TITLE
added top-down camera, and possibility to use QT functions

### DIFF
--- a/experiments/Random_CPFA_r24_tag256_10by10.xml
+++ b/experiments/Random_CPFA_r24_tag256_10by10.xml
@@ -42,7 +42,7 @@
         <CPFA PrintFinalScore="1" ProbabilityOfReturningToNest="0.0147598869881" ProbabilityOfSwitchingToSearching="0.723128706375" RateOfInformedSearchDecay="0.205799848158" RateOfLayingPheromone="14.7027566005" RateOfPheromoneDecay="0.0245057227138" RateOfSiteFidelity="14.1514206414" UninformedSearchVariation="2.81939731297"/>
 
          <settings ClusterWidthX="8" ClusterWidthY="8" DrawDensityRate="4" DrawIDs="1" 
-	 DrawTargetRays="0" DrawTrails="0" FoodDistribution="0" FoodItemCount="256" 
+	 DrawTargetRays="1" DrawTrails="0" FoodDistribution="2" FoodItemCount="256" 
 	 FoodRadius="0.05" MaxSimCounter="1" MaxSimTimeInSeconds="1800" 
 	 NestElevation="0.001" NestPosition="0,0" NestRadius="0.5" NumberOfClusters="4" OutputData="0" 
 	 PowerlawFoodUnitCount="256" VariableFoodPlacement="0"/>
@@ -136,15 +136,22 @@
   <!-- ****************** -->
 
 
-<!-- <visualization>
+ <visualization> 
 
-<qt-opengl>
-      <camera>
-        <placement idx="0" position="  0, 0, 10" look_at="0, 0, 0" lens_focal_length="25"/>
-      </camera>
-      <user_functions label="CPFA_qt_user_functions"/>
+ <qt-opengl>
+        <camera>
+          <placements>
+            <placement index="0" position="0,0,13" look_at="0,0,0" up="0,1,0" lens_focal_length="35"/>
+            <placement index="1" position="0,-9,5" look_at="0,0,0" up="0,1,0" lens_focal_length="35"/>
+            <placement index="2" position="0,9,5" look_at="0,0,0" up="0,-1,0" lens_focal_length="35"/>
+            <placement index="3" position="4,0,5" look_at="0,0,0" up="-1,0,0" lens_focal_length="20"/>
+            <placement index="4" position="-4,0,5" look_at="0,0,0" up="1,0,0" lens_focal_length="20"/>
+            <placement index="5" position="-3,0,2" look_at="1,0,0" up="1,0,0" lens_focal_length="35"/>
+          </placements>
+        </camera>
+        <user_functions label="CPFA_qt_user_functions"/>
     </qt-opengl>
 
-  </visualization> -->
+  </visualization> 
 
 </argos-configuration>


### PR DESCRIPTION
Check experiments
```xml
 <qt-opengl>
        <camera>
          <placements>
            <placement index="0" position="0,0,13" look_at="0,0,0" up="0,1,0" lens_focal_length="35"/>
            <placement index="1" position="0,-9,5" look_at="0,0,0" up="0,1,0" lens_focal_length="35"/>
            <placement index="2" position="0,9,5" look_at="0,0,0" up="0,-1,0" lens_focal_length="35"/>
            <placement index="3" position="4,0,5" look_at="0,0,0" up="-1,0,0" lens_focal_length="20"/>
            <placement index="4" position="-4,0,5" look_at="0,0,0" up="1,0,0" lens_focal_length="20"/>
            <placement index="5" position="-3,0,2" look_at="1,0,0" up="1,0,0" lens_focal_length="35"/>
          </placements>
        </camera>
        <user_functions label="CPFA_qt_user_functions"/>
    </qt-opengl>
```
Added better cameras, and modifications to the display will be done in the CPFA_qt_user_functions.cpp file.

