### PR TITLE
Robots follow pheromones unconditionally, missing decay and probabili…

### DIFF
--- a/experiments/Random_CPFA_r24_tag256_10by10.xml
+++ b/experiments/Random_CPFA_r24_tag256_10by10.xml
@@ -68,9 +68,10 @@
                 DrawDensityRate="4" 
                 DrawIDs="1" 
                 DrawTargetRays="0" 
+                DrawPheromoneShared="1"
                 DrawTrails="0" 
                 FoodDistribution="2" 
-                FoodItemCount="256" 
+                FoodItemCount="100" 
                 FoodRadius="0.05" 
                 MaxSimCounter="1" 
                 MaxSimTimeInSeconds="720" 
@@ -117,7 +118,7 @@
            <distribute>
       <position center="1, 1, 0.0" distances="0.3, 0.3, 0.0" layout="2, 3, 1" method="grid"/>
       <orientation method="constant" values="0.0, 0.0, 0.0"/>
-      <entity max_trials="100" quantity="6">
+      <entity max_trials="100" quantity="1">
         <foot-bot id="F0">
           <controller config="CPFA"/>
         </foot-bot>
@@ -127,7 +128,7 @@
            <distribute>
       <position center="1, -1, 0.0" distances="0.3, 0.3, 0.0" layout="2, 3, 1" method="grid"/>
       <orientation method="constant" values="0.0, 0.0, 0.0"/>
-      <entity max_trials="100" quantity="6">
+      <entity max_trials="100" quantity="1">
         <foot-bot id="F1">
           <controller config="CPFA"/>
         </foot-bot>
@@ -137,7 +138,7 @@
                <distribute>
       <position center="-1, 1, 0.0" distances="0.3, 0.3, 0.0" layout="2, 3, 1" method="grid"/>
       <orientation method="constant" values="0.0, 0.0, 0.0"/>
-      <entity max_trials="100" quantity="6">
+      <entity max_trials="100" quantity="1">
         <foot-bot id="F2">
           <controller config="CPFA"/>
         </foot-bot>
@@ -147,7 +148,7 @@
                <distribute>
       <position center="-1, -1, 0.0" distances="0.3, 0.3, 0.0" layout="2, 3, 1" method="grid"/>
       <orientation method="constant" values="0.0, 0.0, 0.0"/>
-      <entity max_trials="100" quantity="6">
+      <entity max_trials="100" quantity="1">
         <foot-bot id="F3">
           <controller config="CPFA"/>
         </foot-bot>

--- a/source/CPFA/CPFA_controller.cpp
+++ b/source/CPFA/CPFA_controller.cpp
@@ -371,6 +371,7 @@ void CPFA_controller::Searching() {
 	if(IsHoldingFood() == false) {
 		   argos::CVector2 distance = GetPosition() - GetTarget();
 		   argos::Real     random   = RNG->Uniform(argos::CRange<argos::Real>(0.0, 1.0));
+		   PheromoneSharing(); // Check if there are pheromones to share and if there are nearby robots to share with
      
      // If we reached our target search location, set a new one. The 
      // new search location calculation is different based on whether
@@ -378,14 +379,6 @@ void CPFA_controller::Searching() {
      if(distance.SquareLength() < TargetDistanceTolerance) {
          // randomly give up searching
          if(SimulationTick()% (5*SimulationTicksPerSecond())==0 && random < LoopFunctions->ProbabilityOfReturningToNest) {
-             if(LoopFunctions->IsMessageAvailable(GetRobotID())) {
-			MessageType message = LoopFunctions->ReceiveMessage(GetRobotID());
-			cout << "Robot " << GetId() << " (" << GetRobotID() << ") received pheromone trail to follow at " << message.trail.GetX() << ", " << message.trail.GetY() << endl;
-			PheromonShared = message.trail;
-			isUsingPheromone = true;
-			CPFA_state = SEARCHING;
-			survey_count = 0; // Reset
-		}
              SetFidelityList();
 	      TrailToShare.clear();
              SetIsHeadingToNest(true);
@@ -532,13 +525,15 @@ void CPFA_controller::Surveying() {
 		survey_count = 0; // Reset
                 searchingTime+=SimulationTick()-startTime;//qilu 10/22
                 startTime = SimulationTick();//qilu 10/22
+		PheromoneSharing(); // Check if there are pheromones to share and if there are nearby robots to share with
             
 	}
+	
 }
 
 void CPFA_controller::PheromoneSharing() {
 	// Check if there are pheromones to share and if there are nearby robots to share with
-	if(!TrailToShare.empty() && !hasMidRouteShared) { // REFACTOR: It should be able to share the trail to more than one robot, but we need to define decay of the shared location per robot or level, look at PoissonCDF for laying pheromone and maybe add a separate one for sharing pheromone. For now, just share to one robot and then don't share again until the next time it picks up food.
+	if(IsHoldingFood() && !TrailToShare.empty() && !hasMidRouteShared) { // REFACTOR: It should be able to share the trail to more than one robot, but we need to define decay of the shared location per robot or level, look at PoissonCDF for laying pheromone and maybe add a separate one for sharing pheromone. For now, just share to one robot and then don't share again until the next time it picks up food.
 		// Check for nearby robots within 1 meter
 		argos::CSpace::TMapPerType& footbots = LoopFunctions->GetSpace().GetEntitiesByType("foot-bot");
 		argos::CSpace::TMapPerType::iterator it;
@@ -568,6 +563,26 @@ void CPFA_controller::PheromoneSharing() {
 			}
 		}
 	}
+	else if(LoopFunctions->IsMessageAvailable(GetRobotID()) && !IsHoldingFood()) {
+		MessageType message = LoopFunctions->ReceiveMessage(GetRobotID());
+		cout << "Robot " << GetId() << " (" << GetRobotID() << ") received pheromone trail to follow at " << message.trail.GetX() << ", " << message.trail.GetY() << endl;
+		isUsingPheromone = true;
+		// Drop what we're doing and head directly to the trail destination
+		SiteFidelityPosition = message.trail;
+		isInformed = true;
+		isUsingSiteFidelity = false;
+		SetIsHeadingToNest(false);
+		SetTarget(message.trail);
+		CPFA_state = DEPARTING;
+		survey_count = 0;
+
+		// Draw a line from this robot to the trail destination it just received
+		const argos::Real msgRayHeight = 0.15;
+		argos::CVector3 fromPos(GetPosition().GetX(), GetPosition().GetY(), msgRayHeight);
+		argos::CVector3 toPos(message.trail.GetX(), message.trail.GetY(), msgRayHeight);
+		LoopFunctions->PheromoneShared.push_back(argos::CRay3(fromPos, toPos));
+		LoopFunctions->PheromoneSharedColor.push_back(argos::CColor::MAGENTA);
+	}
 }
 
 
@@ -580,13 +595,8 @@ void CPFA_controller::Returning() {
  //LOG<<"Returning..."<<endl;
 	//SetHoldingFood();
 
-	if(IsHoldingFood()) {
-		PheromoneSharing();
-	}
-	else{
-		
-		
-	}
+	PheromoneSharing(); // Check if there are pheromones to share and if there are nearby robots to share with
+
 	// Are we there yet? (To the nest, that is.)
 	if(IsInTheNest()) {
 		// Based on a Poisson CDF, the robot may or may not create a pheromone

--- a/source/CPFA/CPFA_controller.h
+++ b/source/CPFA/CPFA_controller.h
@@ -53,7 +53,7 @@ class CPFA_controller : public BaseController {
 		std::vector<argos::CVector2> TrailToShare; // For sharing a pheromone trail with another robot
 		std::vector<argos::CVector2> TrailToFollow; // For following a shared pheromone trail
 		std::vector<argos::CRay3>    MyTrail; // for drawing the trail to the target
-		argos::CVector2 PheromonShared; // position of the shared pheromone
+		argos::CVector2 PheromoneShared; // position of the shared pheromone
 
 		/* robot position variables */
 		argos::CVector2 SiteFidelityPosition;

--- a/source/CPFA/CPFA_loop_functions.cpp
+++ b/source/CPFA/CPFA_loop_functions.cpp
@@ -20,6 +20,7 @@ CPFA_loop_functions::CPFA_loop_functions() :
 	DrawIDs(1),
 	DrawTrails(1),
 	DrawTargetRays(1),
+	DrawPheromoneShared(1),
 	FoodDistribution(2),
 	FoodItemCount(256),
 	PowerlawFoodUnitCount(256),
@@ -73,6 +74,7 @@ void CPFA_loop_functions::Init(argos::TConfigurationNode &node) {
 	argos::GetNodeAttribute(settings_node, "DrawIDs", DrawIDs);
 	argos::GetNodeAttribute(settings_node, "DrawTrails", DrawTrails);
 	argos::GetNodeAttribute(settings_node, "DrawTargetRays", DrawTargetRays);
+	argos::GetNodeAttribute(settings_node, "DrawPheromoneShared", DrawPheromoneShared);
 	argos::GetNodeAttribute(settings_node, "FoodDistribution", FoodDistribution);
 	argos::GetNodeAttribute(settings_node, "FoodItemCount", FoodItemCount);
 	argos::GetNodeAttribute(settings_node, "PowerlawFoodUnitCount", PowerlawFoodUnitCount);
@@ -159,6 +161,8 @@ void CPFA_loop_functions::Reset() {
 	PheromoneList.clear();
 	FidelityList.clear();
     TargetRayList.clear();
+	PheromoneShared.clear();
+	PheromoneSharedColor.clear();
     
     SetFoodDistribution();
     
@@ -197,6 +201,8 @@ void CPFA_loop_functions::PreStep() {
 	FidelityList.clear();
 	PheromoneList.clear();
         TargetRayList.clear();
+        PheromoneShared.clear();
+        PheromoneSharedColor.clear();
     }
 }
 

--- a/source/CPFA/CPFA_loop_functions.h
+++ b/source/CPFA/CPFA_loop_functions.h
@@ -98,6 +98,7 @@ class CPFA_loop_functions : public argos::CLoopFunctions
 		argos::Real getSimTimeInSeconds();
 
 		std::vector<argos::CColor>   TargetRayColorList;
+		std::vector<argos::CColor>   PheromoneSharedColor; // color for drawing the shared pheromone
 
 		unsigned int getNumberOfRobots();
         void increaseNumDistributedFoodByOne();
@@ -133,6 +134,7 @@ class CPFA_loop_functions : public argos::CLoopFunctions
 		size_t DrawIDs;
 		size_t DrawTrails;
 		size_t DrawTargetRays;
+		size_t DrawPheromoneShared;
 		size_t FoodDistribution;
 		size_t FoodItemCount;
 		size_t PowerlawFoodUnitCount;
@@ -174,6 +176,7 @@ class CPFA_loop_functions : public argos::CLoopFunctions
                 map<string, argos::CVector2> FidelityList; 
 		std::vector<Pheromone>   PheromoneList; 
 		std::vector<argos::CRay3>    TargetRayList;
+		std::vector<argos::CRay3> PheromoneShared; // position of the shared pheromone
 		argos::CRange<argos::Real>   ForageRangeX;
 		argos::CRange<argos::Real>   ForageRangeY;
   

--- a/source/CPFA/CPFA_qt_user_functions.cpp
+++ b/source/CPFA/CPFA_qt_user_functions.cpp
@@ -53,6 +53,7 @@ void CPFA_qt_user_functions::DrawOnArena(CFloorEntity& entity) {
 	DrawNest();
 
 	if(loopFunctions.DrawTargetRays == 1) DrawTargetRays();
+	if(loopFunctions.DrawPheromoneShared == 1) DrawPheromoneShared();
 }
 
 /*****
@@ -164,6 +165,14 @@ void CPFA_qt_user_functions::DrawTargetRays() {
 			DrawRay(loopFunctions.TargetRayList[j], loopFunctions.TargetRayColorList[j]);
 		}
 	//}
+}
+
+void CPFA_qt_user_functions::DrawPheromoneShared() {
+	for(size_t i = 0; i < loopFunctions.PheromoneShared.size(); i++) {
+		//cout << "Drawing shared pheromone at " << loopFunctions.PheromoneShared[i] << endl;
+		// Draw a ray from robot to the shared pheromone location in real time
+		DrawRay(loopFunctions.PheromoneShared[i], loopFunctions.PheromoneSharedColor[i]);
+	}
 }
 
 /*

--- a/source/CPFA/CPFA_qt_user_functions.h
+++ b/source/CPFA/CPFA_qt_user_functions.h
@@ -30,6 +30,7 @@ class CPFA_qt_user_functions : public argos::CQTOpenGLUserFunctions {
 		void DrawFidelity();
 		void DrawPheromones();
 		void DrawTargetRays();
+		void DrawPheromoneShared();
 
 		CPFA_loop_functions& loopFunctions;
  


### PR DESCRIPTION
Updated Controller and QT Functions to follow the shared pheromone.

The robot will always follow the pheromone shared as long as it is not holding food or not following a pheromone already.
Added a simple visualization, a magenta ray will appear from the robot that received the message to the location it will visit.

ISSUES left to fix:

    Add decay to the sharing, right now we are using hasMidRouteShared to check if the pheromone was shared.

    Ideas for this, use the GetPoissonCDF function with the message strength to decide if we should follow and further share the pheromone.
